### PR TITLE
Format + Typo of config.toml

### DIFF
--- a/examples/multilingual/config.toml
+++ b/examples/multilingual/config.toml
@@ -7,21 +7,21 @@ publishdir = "public"
 IsMultiLingual = true
 DefaultContentLanguage = "en"
 
-# If set to true, each language will be available under it's language code url. 
+# If set to true, each language will be available under it's language code url.
 # For example: www.example.com/en/ and www.example.com/de/
 # Else, the default language will be available under www.example.com/
 DefaultContentLanguageInSubdir = false
 
 
-# In the section below, only site variables can be defined and translated. 
-# For example, you **cannot** define a `my_custom_var` and have it translated here. 
- 
+# In the section below, only site variables can be defined and translated. For
+# example, you **cannot** define a `my_custom_var` and have it translated here.
+
 [Languages]
     [Languages.en]
         weight = 1
         title = "Hugo Multilingual Example"
         copyright = "© All rights reserved"
-    
+
     [Languages.fr]
         weight = 2
         title = "Exemple de site multilingue avec Hugo"

--- a/examples/multilingual/config.toml
+++ b/examples/multilingual/config.toml
@@ -8,7 +8,7 @@ IsMultiLingual = true
 DefaultContentLanguage = "en"
 
 # If set to true, each language will be available under it's language code url. 
-# For example: www.example.com/en and www.example.com.de
+# For example: www.example.com/en/ and www.example.com/de/
 # Else, the default language will be available under www.example.com/
 DefaultContentLanguageInSubdir = false
 


### PR DESCRIPTION
Small changes to `config.toml` (fix of a typo, remove trailing whitespaces, ensure maximum width of 80 characters)